### PR TITLE
Fix new API Endpoint and too many API requests

### DIFF
--- a/custom_components/poollab/__init__.py
+++ b/custom_components/poollab/__init__.py
@@ -39,7 +39,7 @@ class PoolLabCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name="PoolLab API",
-            update_interval=timedelta(seconds=30),
+            update_interval=timedelta(seconds=60),
             update_method=self._async_update_data,
         )
         self.api = api

--- a/custom_components/poollab/poollab.py
+++ b/custom_components/poollab/poollab.py
@@ -6,7 +6,7 @@ from typing import Any
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 
-API_ENDPOINT = "https://backend.labcom.cloud/graphql"
+API_ENDPOINT = "https://production.backend.labcom.cloud/graphql"
 
 # Measurement ranges according to https://poollab.org/static/manuals/poollab_manual_gb-fr-e-d-i.pdf
 MEAS_RANGES_BY_SCENARIO = {


### PR DESCRIPTION
- Fix the API endpoint with the new URL
- Set the coordinator update interval to 60 seconds instead of 30s in order to fix “too many API requests”