### PR TITLE
Update poollab.py

### DIFF
--- a/custom_components/poollab/poollab.py
+++ b/custom_components/poollab/poollab.py
@@ -260,7 +260,7 @@ class PoolLabApi:
         if schema is None:
             schema = self._build_schema()
         transport = AIOHTTPTransport(
-            url=self._url, headers={"Authorization": self._token}
+            url=self._url, headers={"Authorization": self._token}, ssl=True
         )
         async with Client(
             transport=transport,


### PR DESCRIPTION
Set ssl=True when initializing AIOHTTPTransport to enforce SSL certificate verification and suppress repeated warning messages in the HA logs.