### PR TITLE
Improvements for HA installation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,48 @@
 
 ![Logo](PoolLab.jpg)
 # Python PoolLab (Home Assistant)
-Python API for Pool Lab 1.0
-For now only fetching all data and parsing to classes.
+Python API for Pool Lab Photometers. For now only fetching all data and parsing to classes.
+
+## Home Assistant integration
+
+### Install via HACS
+
+> [!TIP]
+> Python Poollab is available in the default HACS repository. You can install it directly through HACS or click the button below to open it there.
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=dala318&repository=python_poollab)
+
+_or_
+
+1. Install HACS if you don't have it already
+2. Open HACS in Home Assistant
+3. Search for "Poollab"
+4. Click the download button. ⬇️
+5. Restart Home Assistant
+
+### Configuration
+1. Get a Pool Lab API token to your cloud data from https://labcom.cloud/pages/user-setting
+2. Add the Pool Lab integration to your HA by clicking this My Home Assistant link: https://my.home-assistant.io/redirect/config_flow_start/?domain=poollab
+   
+   _or_
+   
+   Navigate to Home Assistant settings, "devices and integrations", click "Add integration" in the right bottom and select "Pool Lab"
+3. In the configuration window enter the API token obtained in step 1
+4. Each pool in your account should be shown as an own device which you can add to a room
+
+![Example device](device_integration_example.png)
+
+### Entity attributes
+Each sensor entity has the value of the last measurement of each parameter, based on the timestamp from device (not the one stored last)
+In addition some attributes are provided:
+* `Measured at`: The device timestamp at measure
+* `Measure`: The unique id of the measure
+* `Ideal low`: Lower limit for ok
+* `Ideal high`: Upper limit for ok
+* `Device serial`: Device serial of the device that made the measure
+* `Operator name`: Mane of operator that did the measurement
+* `Comment`: Comment to measurement
+
 
 ## Stand-alone usage
 You only need the file [poollab.py](custom_components/poollab/poollab.py)
@@ -16,31 +56,3 @@ from poollab import PoolLabApi
 poollab_api = PoolLabApi("API_TOKEN_FROM_https://labcom.cloud/pages/user-setting")
 print(asyncio.run(poollab_api.request()))
 ```
-
-## Home Assistant integration
-
-### Install
-1. Go to HACS -> Integrations
-2. Click the three dots on the top right and select `Custom Repositories`
-3. Enter `https://github.com/dala318/python_poollab` as repository, select the category `Integration` and click Add
-4. A new custom integration shows up for installation (PoolLab) - install it
-5. Restart Home Assistant
-
-### Configuration
-1. Get a API token to your cloud data from https://labcom.cloud/pages/user-setting
-2. Klick Add integration and select "poollab"
-3. In the configuration window enter the API token
-4. Each pool in your account should be shown as an own device which you can add to a room
-
-![Example device](device_integration_example.png)
-
-### Entity attributes
-Each sensor entity has the value of the last measurement of each parameter, based on the timestamp from device (not the one stored last)
-In addition some attributes are provided
-* `Measured at`: The device timestamp at measure
-* `Measure`: The unique id of the measure
-* `Ideal low`: Lower limit for ok
-* `Ideal high`: Upper limit for ok
-* `Device serial`: Device serial of the device that made the measure
-* `Operator name`: Mane of operator that did the measurement
-* `Comment`: Comment to measurement

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _or_
 
 1. Install HACS if you don't have it already
 2. Open HACS in Home Assistant
-3. Search for "Poollab"
+3. Search for "Pool Lab"
 4. Click the download button. ⬇️
 5. Restart Home Assistant
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "PoolLab",
+    "name": "Pool Lab",
     "render_readme": true,
     "zip_release": true,
     "filename": "poollab.zip"


### PR DESCRIPTION
Well, subject says it all 😉 
Preview: https://github.com/dala318/python_poollab/blob/7c9de41ae0822c4e1a4d523e229d04de96ea8e28/README.md

- Took the liberty to move the "stand-alone" instructions to the bottom of the file, as the readme will be rendered by HACS as well so having HA relevant info "up front" makes sense.
- Added a space in hacs.json for consistent naming throughout HACS, as you use `Pool Lab` everywhere else